### PR TITLE
docs: add missing Vue.use(VueI18n)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ npm i @vue/composition-api
 ```js
 // main.js
 import Vue from 'vue'
+import VueI18n from 'vue-i18n'
 import { createI18n } from 'vue-i18n-composable'
 import App from './App.vue'
+
+Vue.use(VueI18n)
 
 const i18n = createI18n({
   locale: 'ja',
@@ -79,11 +82,13 @@ export default defineComponent({
 ```js
 // main.js
 import Vue from 'vue'
+import VueI18n from 'vue-i18n'
 import VueCompositionAPI, { createApp } from '@vue/composition-api'
 import { createI18n } from 'vue-i18n-composable'
 import App from './App.vue'
 
 Vue.use(VueCompositionAPI)
+Vue.use(VueI18n)
 
 const i18n = createI18n({
   locale: 'ja',


### PR DESCRIPTION
In the newly released v1 and v2, `Vue.use(VueI18n)` is removed from `createI18n`, so users should call it manually. Now `createI18n` does not need and accept a second parameter which is also a breaking change in unit test.